### PR TITLE
[Track A] Implement RadarView with 3 focus area cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - **SAPUI5 project structure** - Complete webapp folder structure with Component.js, manifest.json, views, controllers, i18n, and routing
+- **RadarView with focus area cards** - Three cards (Voice AI, Agent Orchestration, Durable Runtime) with signal/noise sections using CSS Grid layout
 - **Signal vs Noise classification** - Core feature to distinguish actionable technical findings from marketing hype
 - `signal_evidence` and `noise_indicators` fields in Golden Contract schema
 - Mock data with signal and noise examples for each focus area (6 items total)

--- a/webapp/css/style.css
+++ b/webapp/css/style.css
@@ -1,1 +1,18 @@
 /* Application-specific styles */
+
+/* Signal item styling */
+.signalItem {
+    color: #107e3e;
+    padding: 0.25rem 0;
+}
+
+/* Noise item styling */
+.noiseItem {
+    color: #bb0000;
+    padding: 0.25rem 0;
+}
+
+/* Card content padding */
+.sapFCard .sapMVBox {
+    padding: 0.5rem;
+}

--- a/webapp/i18n/i18n.properties
+++ b/webapp/i18n/i18n.properties
@@ -5,3 +5,16 @@ appDescription=Technology trends radar application for tracking emerging technol
 # Radar View
 radarViewTitle=Technology Radar
 welcomeMessage=Welcome to the Technology Trends Radar
+
+# Focus Area Cards
+voiceAiTitle=Voice AI
+voiceAiSubtitle=Speech recognition and voice interfaces
+agentOrchTitle=Agent Orchestration
+agentOrchSubtitle=Multi-agent coordination and workflows
+durableRuntimeTitle=Durable Runtime
+durableRuntimeSubtitle=Long-running process execution
+
+# Signal/Noise Labels
+signalLabel=Signal
+noiseLabel=Noise
+noDataAvailable=No data available

--- a/webapp/view/RadarView.view.xml
+++ b/webapp/view/RadarView.view.xml
@@ -1,13 +1,81 @@
 <mvc:View
     controllerName="tech.trends.radar.controller.RadarView"
     xmlns:mvc="sap.ui.core.mvc"
-    xmlns="sap.m">
+    xmlns="sap.m"
+    xmlns:f="sap.f"
+    xmlns:grid="sap.ui.layout.cssgrid">
     <Page
         id="radarPage"
         title="{i18n>radarViewTitle}"
         showNavButton="false">
         <content>
-            <Text text="{i18n>welcomeMessage}" class="sapUiMediumMargin" />
+            <grid:CSSGrid id="focusAreaGrid" gridTemplateColumns="repeat(auto-fit, minmax(20rem, 1fr))" gridGap="1rem" class="sapUiSmallMargin">
+                <!-- Voice AI Card -->
+                <f:Card id="voiceAiCard" class="sapUiSmallMargin">
+                    <f:header>
+                        <f:cards.Header
+                            title="{i18n>voiceAiTitle}"
+                            subtitle="{i18n>voiceAiSubtitle}"
+                            iconSrc="sap-icon://microphone" />
+                    </f:header>
+                    <f:content>
+                        <VBox class="sapUiSmallMargin">
+                            <Title text="{i18n>signalLabel}" level="H5" class="sapUiTinyMarginBottom" />
+                            <VBox id="voiceAiSignals" class="sapUiTinyMarginBottom">
+                                <Text text="{i18n>noDataAvailable}" />
+                            </VBox>
+                            <Title text="{i18n>noiseLabel}" level="H5" class="sapUiTinyMarginBottom" />
+                            <VBox id="voiceAiNoise">
+                                <Text text="{i18n>noDataAvailable}" />
+                            </VBox>
+                        </VBox>
+                    </f:content>
+                </f:Card>
+
+                <!-- Agent Orchestration Card -->
+                <f:Card id="agentOrchCard" class="sapUiSmallMargin">
+                    <f:header>
+                        <f:cards.Header
+                            title="{i18n>agentOrchTitle}"
+                            subtitle="{i18n>agentOrchSubtitle}"
+                            iconSrc="sap-icon://process" />
+                    </f:header>
+                    <f:content>
+                        <VBox class="sapUiSmallMargin">
+                            <Title text="{i18n>signalLabel}" level="H5" class="sapUiTinyMarginBottom" />
+                            <VBox id="agentOrchSignals" class="sapUiTinyMarginBottom">
+                                <Text text="{i18n>noDataAvailable}" />
+                            </VBox>
+                            <Title text="{i18n>noiseLabel}" level="H5" class="sapUiTinyMarginBottom" />
+                            <VBox id="agentOrchNoise">
+                                <Text text="{i18n>noDataAvailable}" />
+                            </VBox>
+                        </VBox>
+                    </f:content>
+                </f:Card>
+
+                <!-- Durable Runtime Card -->
+                <f:Card id="durableRuntimeCard" class="sapUiSmallMargin">
+                    <f:header>
+                        <f:cards.Header
+                            title="{i18n>durableRuntimeTitle}"
+                            subtitle="{i18n>durableRuntimeSubtitle}"
+                            iconSrc="sap-icon://it-host" />
+                    </f:header>
+                    <f:content>
+                        <VBox class="sapUiSmallMargin">
+                            <Title text="{i18n>signalLabel}" level="H5" class="sapUiTinyMarginBottom" />
+                            <VBox id="durableRuntimeSignals" class="sapUiTinyMarginBottom">
+                                <Text text="{i18n>noDataAvailable}" />
+                            </VBox>
+                            <Title text="{i18n>noiseLabel}" level="H5" class="sapUiTinyMarginBottom" />
+                            <VBox id="durableRuntimeNoise">
+                                <Text text="{i18n>noDataAvailable}" />
+                            </VBox>
+                        </VBox>
+                    </f:content>
+                </f:Card>
+            </grid:CSSGrid>
         </content>
     </Page>
 </mvc:View>


### PR DESCRIPTION
## Summary
- Add CSS Grid layout with 3 focus area cards
- Voice AI, Agent Orchestration, Durable Runtime cards
- Each card has signal/noise sections with placeholders
- Added i18n texts and CSS styling for signal (green) / noise (red)

## Test plan
- [ ] Run `npm start` to verify app launches
- [ ] Verify 3 cards display in responsive grid
- [ ] Run `npm run lint` to verify 0 linter errors

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)